### PR TITLE
[change] Working directory can now be set to any directory

### DIFF
--- a/chemts_mothods.py
+++ b/chemts_mothods.py
@@ -21,8 +21,8 @@ class Methods:
     def __init__(self, conf=None):
         self.conf = conf
         self.logger = self.setup_custom_logger('ChemTS', os.path.join('logs', 'ChemTS.log'))
-        self.chemts_config_path = os.path.join(self.conf.target_dirname, '_setting.yaml')
-        print("config_path=>", self.chemts_config_path)
+        #self.chemts_config_path = os.path.join(self.conf.target_dirname, '_setting.yaml')
+        #print("config_path=>", self.chemts_config_path)
 
     def setup_custom_logger(self, name, log_file, log_level=logging.INFO):
         logger = logging.getLogger(name)
@@ -225,7 +225,8 @@ class Methods:
             dscore_parameters[key]['max'] = configs[key]['max']
             dscore_parameters[key]['min'] = configs[key]['min']
 
-        with open(self.chemts_config_path, 'w') as f:
+      
+        with open(self.target_dirname, 'w') as f:
             yaml.dump(chemts_config, f, default_flow_style=False, sort_keys=False)
 
     # def csv_to_mol2(self, csv, output_path_prefix, ligand_pdb):

--- a/chemts_mothods.py
+++ b/chemts_mothods.py
@@ -225,8 +225,8 @@ class Methods:
             dscore_parameters[key]['max'] = configs[key]['max']
             dscore_parameters[key]['min'] = configs[key]['min']
 
-      
-        with open(self.target_dirname, 'w') as f:
+        t_file = os.path.join(chemts_config['target_dirname'], '_setting.yaml')
+        with open(t_file, 'w') as f:
             yaml.dump(chemts_config, f, default_flow_style=False, sort_keys=False)
 
     # def csv_to_mol2(self, csv, output_path_prefix, ligand_pdb):

--- a/chemts_mothods.py
+++ b/chemts_mothods.py
@@ -21,7 +21,7 @@ class Methods:
     def __init__(self, conf=None):
         self.conf = conf
         self.logger = self.setup_custom_logger('ChemTS', os.path.join('logs', 'ChemTS.log'))
-        self.chemts_config_path = os.path.join(self.target_dirname, '_setting.yaml')
+        self.chemts_config_path = os.path.join(self.conf.target_dirname, '_setting.yaml')
         print("config_path=>", self.chemts_config_path)
 
     def setup_custom_logger(self, name, log_file, log_level=logging.INFO):

--- a/chemts_mothods.py
+++ b/chemts_mothods.py
@@ -21,7 +21,7 @@ class Methods:
     def __init__(self, conf=None):
         self.conf = conf
         self.logger = self.setup_custom_logger('ChemTS', os.path.join('logs', 'ChemTS.log'))
-        self.chemts_config_path = os.path.join('ChemTSv2', 'work', '_setting.yaml')
+        self.chemts_config_path = os.path.join(self.target_dirname, '_setting.yaml')
 
     def setup_custom_logger(self, name, log_file, log_level=logging.INFO):
         logger = logging.getLogger(name)

--- a/chemts_mothods.py
+++ b/chemts_mothods.py
@@ -22,6 +22,7 @@ class Methods:
         self.conf = conf
         self.logger = self.setup_custom_logger('ChemTS', os.path.join('logs', 'ChemTS.log'))
         self.chemts_config_path = os.path.join(self.target_dirname, '_setting.yaml')
+        print("config_path=>", self.chemts_config_path)
 
     def setup_custom_logger(self, name, log_file, log_level=logging.INFO):
         logger = logging.getLogger(name)

--- a/chemtsv2/utils.py
+++ b/chemtsv2/utils.py
@@ -2,6 +2,7 @@ import copy
 from functools import wraps
 import itertools
 import sys
+import os
 import time
 
 import joblib
@@ -14,6 +15,7 @@ import selfies as sf
 
 from chemtsv2.misc.manage_qsub_parallel import run_qsub_parallel
 
+cwd = os.path.dirname(os.path.abspath(__file__))
 
 def calc_execution_time(f):
     @wraps(f)
@@ -112,7 +114,7 @@ def neutralize_atoms(mol):
 
 
 def get_model_structure_info(model_json, logger):
-    with open(model_json, 'r') as f:
+    with open(os.path.join(cwd,'../', model_json), 'r') as f:
         loaded_model_json = f.read()
     loaded_model = model_from_json(loaded_model_json)
     logger.info(f"Loaded model_json from {model_json}")
@@ -142,7 +144,7 @@ def loaded_model(model_weight, logger, conf):
                   return_sequences=True, stateful=True))
     model.add(GRU(256, activation='tanh', return_sequences=False, stateful=True))
     model.add(Dense(conf['rnn_output_size'], activation='softmax'))
-    model.load_weights(model_weight)
+    model.load_weights(os.path.join(cwd,'../',model_weight))
     logger.info(f"Loaded model_weight from {model_weight}")
 
     return model

--- a/filter/sascore_filter.py
+++ b/filter/sascore_filter.py
@@ -1,6 +1,10 @@
 import sys
-sys.path.append("./data/")
-import sascorer
+import os
+
+cwd = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.append(os.path.join(cwd,"../data/"))
+import data.sascorer as sascorer
 
 from chemtsv2.filter import Filter
 

--- a/generate_lead.py
+++ b/generate_lead.py
@@ -87,9 +87,13 @@ class Generate_Lead:
                     rearrange_smi = self.cm.modify_smiles(rearrange_smi)
 
                 self.logger.info(f"rearrange_smi , {rearrange_smi}")
-
-                os.makedirs(os.path.join(cwd, 'work'), exist_ok=True)
-                subprocess.run(['rm', os.path.join('work', '_setting.yaml')], cwd=cwd)
+                
+                # smiles output のロケーションが固定されている
+                # /ChemTSv2に変更するため、この設定はPermission Denied
+                #os.makedirs(os.path.join(cwd, 'work'), exist_ok=True)
+                os.makedirs(os.path.join(cwd, self.target_dirname), exist_ok=True)
+                #subprocess.run(['rm', os.path.join('work', '_setting.yaml')], cwd=cwd)
+                subprocess.run(['rm', os.path.join(self.target_dirname, '_setting.yaml')], cwd=cwd)
                 self.cm.make_config_file({**config_add_props, **sincho_result}, weight_model_dir)
 
                 # 化合物生成をn回

--- a/generate_lead.py
+++ b/generate_lead.py
@@ -11,7 +11,6 @@ from ChemTSv2.chemts_mothods import Methods, logs_dir
 import logging
 
 cwd = os.path.dirname(os.path.abspath(__file__))
-# target_dirname = 'work/results'
 
 class Generate_Lead:
     def __init__(self, trajectory_dirs, config):
@@ -90,36 +89,36 @@ class Generate_Lead:
                 
                 # smiles output のロケーションが固定されている
                 # /ChemTSv2に変更するため、この設定はPermission Denied
-                #os.makedirs(os.path.join(cwd, 'work'), exist_ok=True)
-                os.makedirs(os.path.join(cwd, self.target_dirname), exist_ok=True)
-                #subprocess.run(['rm', os.path.join('work', '_setting.yaml')], cwd=cwd)
-                subprocess.run(['rm', os.path.join(self.target_dirname, '_setting.yaml')], cwd=cwd)
+                os.makedirs(os.path.join(self.target_dirname), exist_ok=True)
+                print(self.target_dirname)
+                subprocess.run(['rm', os.path.join(self.target_dirname, '_setting.yaml')])
                 self.cm.make_config_file({**config_add_props, **sincho_result}, weight_model_dir)
 
+                #print("GOOD")
                 # 化合物生成をn回
                 df_result_all = pd.DataFrame()
                 for n in range(1, int(self.conf['ChemTS']['num_chemts_loops'])+1):
                     with open(self.out_log_file, 'a') as stdout_f:
-                        subprocess.run(['python', 'run.py', '-c', os.path.join('work', '_setting.yaml'), 
-                                        '--input_smiles', rearrange_smi], cwd=cwd, stdout=stdout_f, stderr=stdout_f)
+                        subprocess.run(['python', '/ChemTSv2/run.py', '-c', os.path.join(self.target_dirname, '_setting.yaml'), 
+                                        '--input_smiles', rearrange_smi], stdout=stdout_f, stderr=stdout_f)
                         subprocess.run(' '.join(['mv', os.path.join(self.target_dirname, 'result_C*'), 
                                                        os.path.join(self.target_dirname, 'result.csv')]), 
-                                                       shell=True, cwd=cwd, stdout=stdout_f, stderr=stdout_f)
-                        df_result_one_cycle = pd.read_csv(os.path.join(cwd, self.target_dirname, 'result.csv'))
+                                                       shell=True, stdout=stdout_f, stderr=stdout_f)
+                        df_result_one_cycle = pd.read_csv(os.path.join(self.target_dirname, 'result.csv'))
                         df_result_one_cycle.insert(0, 'trial', n) 
                         df_result_all = pd.concat([df_result_all, df_result_one_cycle])
                         subprocess.run(' '.join(['cat', os.path.join(self.target_dirname, 'run.log'), 
-                                                 '>>', os.path.join(self.target_dirname, 'run.log.all')]), shell=True, cwd=cwd)
+                                                 '>>', os.path.join(self.target_dirname, 'run.log.all')]), shell=True )
                         
                 # for debug df_result_all
-                # df_result_all = pd.read_csv(os.path.join(cwd, self.target_dirname, 'results.csv'))
+                # df_result_all = pd.read_csv(os.path.join(self.target_dirname, 'results.csv'))
                 
                 # n回分を一つのファイルにし、個々のファイルは消しておく
-                output_csv_path = os.path.join(cwd, self.target_dirname, 'results.csv')
+                output_csv_path = os.path.join(self.target_dirname, 'results.csv')
                 df_result_all.to_csv(output_csv_path)
                 subprocess.run(['rm', os.path.join(self.target_dirname, 'result.csv'),], cwd=cwd)
                 
                 # 今回の生成のrewardなどをプロット
                 self.cm.plot_reward(output_csv_path)
 
-                subprocess.run(' '.join(['mv', os.path.join(cwd, self.target_dirname, '*'), rank_output_dir]), shell=True)
+                subprocess.run(' '.join(['mv', os.path.join(self.target_dirname, '*'), rank_output_dir]), shell=True)

--- a/run.py
+++ b/run.py
@@ -21,6 +21,8 @@ from chemtsv2.preprocessing import smi_tokenizer, selfies_tokenizer_from_smiles
 
 from IPython.core.debugger import Pdb
 
+cwd = os.path.dirname(os.path.abspath(__file__))
+
 def get_parser():
     parser = argparse.ArgumentParser(
         description="",
@@ -174,15 +176,6 @@ def main():
     if conf['random_seed'] != -1:
         conf['fix_random_seed'] = True
 
-    # download additional data if files don't exist
-    if not os.path.exists('data/sascorer.py'):
-        url = 'https://raw.githubusercontent.com/rdkit/rdkit/master/Contrib/SA_Score/sascorer.py'
-        with open('data/sascorer.py', 'w') as f:
-            f.write(requests.get(url).text)
-    if not os.path.exists('data/fpscores.pkl.gz'):
-        url = 'https://raw.githubusercontent.com/rdkit/rdkit/master/Contrib/SA_Score/fpscores.pkl.gz'
-        with open('data/fpscores.pkl.gz', 'wb') as f:
-            f.write(requests.get(url).content)
     
     rs = conf['reward_setting']
     reward_calculator = getattr(import_module(rs["reward_module"]), rs["reward_class"])
@@ -211,7 +204,7 @@ def main():
 
     conf['random_generator'] = default_rng(conf['random_seed']) if conf['fix_random_seed'] else default_rng()
 
-    with open(conf['token'], 'rb') as f:
+    with open(os.path.join(cwd,conf['token']), 'rb') as f:
         tokens = pickle.load(f)
     logger.debug(f"Loaded tokens are {tokens}")
 


### PR DESCRIPTION
Previously, when executing generate_lead.py, a working directory (such as ChemTSv2/work/result) was created directly under the ChemTSv2 code directory, and all computations were performed there.
This approach caused a critical error if the ChemTSv2 code was located in a directory without user write permission (e.g., the root / directory).
With this update, output directories are now created based on the paths specified in the input file condition.yaml, under ["ChemTS"]["output_dir"] and ["ChemTS"]["target_dirname"].